### PR TITLE
upgrade to assembly script 0.25 and expose rounding types

### DIFF
--- a/assembly/Big.ts
+++ b/assembly/Big.ts
@@ -3,7 +3,7 @@
  * 
  * All operations are immutable.
  */
- export default class Big {
+export default class Big {
 
     /**
      * {Big} instance with the value zero {0}.
@@ -68,6 +68,26 @@
      *  3  Away from zero.                                  (ROUND_UP)
      */
     static RM: u8 = 1;  // 0, 1, 2 or 3
+
+    /**
+     * Towards zero (i.e. truncate, no rounding).
+     */
+    static readonly ROUND_DOWN: u8 = 0;
+
+    /**
+     * To nearest neighbour. If equidistant, round up.
+     */
+    static readonly ROUND_HALF_UP: u8 = 1;
+
+    /**
+     * To nearest neighbour. If equidistant, to even.
+     */
+    static readonly ROUND_HALF_EVEN: u8 = 2;
+
+    /**
+     * Away from zero.
+     */
+    static readonly ROUND_UP: u8 = 3;
 
     /**
      * Default contructor. 
@@ -614,7 +634,7 @@
             return yb;
         }
 
-        let bl: i32, bt: i32, cmp: i32, ri: i32,
+        let bl: i32, cmp: i32, ri: i32,
             bz = b.slice(),
             ai = bl = b.length,
             al = a.length,
@@ -633,6 +653,8 @@
 
         // add zeros to make remainder as long as divisor
         for (; rl++ < bl;) r.push(0);
+
+        cmp = 0;
 
         let n: u8;
         do {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "as-big",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "as-big",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
-        "assemblyscript": "^0.22.0"
+        "assemblyscript": "^0.25.0"
       }
     },
     "node_modules/assemblyscript": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.22.0.tgz",
-      "integrity": "sha512-BC4tV2hc+oNgKOWfXXrl5iD2W+NkQV1MbRNCMi7YE83VoSzrmJj7LqSJMHYc39nKNnX+MiL4DHzp9zCKIMal/g==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.25.0.tgz",
+      "integrity": "sha512-amIamciuS/sk8a9Ou2PLKyHExIZZIU31mVPEoEISNGJS4ptxbNx27TaQHXrngaW2/AGkpNljWkkzlXUO5K+RHg==",
       "dev": true,
       "dependencies": {
-        "binaryen": "110.0.0-nightly.20221019",
+        "binaryen": "110.0.0-nightly.20221105",
         "long": "^5.2.0"
       },
       "bin": {
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/binaryen": {
-      "version": "110.0.0-nightly.20221019",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-110.0.0-nightly.20221019.tgz",
-      "integrity": "sha512-BmuVpV5hpeU1G9ENWQUslwaxbmol810S3+yd7xVJap+vrSQz7ybXiirwya1FfYSFtuDbfGYPfQAObiW5O2PS1w==",
+      "version": "110.0.0-nightly.20221105",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-110.0.0-nightly.20221105.tgz",
+      "integrity": "sha512-OBESOc51q3SwgG8Uv8nMzGnSq7LJpSB/Fu8B3AjlZg6YtCEwRnlDWlnwNB6mdql+VdexfKmNcsrs4K7MYidmdQ==",
       "dev": true,
       "bin": {
         "wasm-opt": "bin/wasm-opt",
@@ -53,19 +53,19 @@
   },
   "dependencies": {
     "assemblyscript": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.22.0.tgz",
-      "integrity": "sha512-BC4tV2hc+oNgKOWfXXrl5iD2W+NkQV1MbRNCMi7YE83VoSzrmJj7LqSJMHYc39nKNnX+MiL4DHzp9zCKIMal/g==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.25.0.tgz",
+      "integrity": "sha512-amIamciuS/sk8a9Ou2PLKyHExIZZIU31mVPEoEISNGJS4ptxbNx27TaQHXrngaW2/AGkpNljWkkzlXUO5K+RHg==",
       "dev": true,
       "requires": {
-        "binaryen": "110.0.0-nightly.20221019",
+        "binaryen": "110.0.0-nightly.20221105",
         "long": "^5.2.0"
       }
     },
     "binaryen": {
-      "version": "110.0.0-nightly.20221019",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-110.0.0-nightly.20221019.tgz",
-      "integrity": "sha512-BmuVpV5hpeU1G9ENWQUslwaxbmol810S3+yd7xVJap+vrSQz7ybXiirwya1FfYSFtuDbfGYPfQAObiW5O2PS1w==",
+      "version": "110.0.0-nightly.20221105",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-110.0.0-nightly.20221105.tgz",
+      "integrity": "sha512-OBESOc51q3SwgG8Uv8nMzGnSq7LJpSB/Fu8B3AjlZg6YtCEwRnlDWlnwNB6mdql+VdexfKmNcsrs4K7MYidmdQ==",
       "dev": true
     },
     "long": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "asbuild": "npm run asbuild:debug && npm run asbuild:release"
   },
   "devDependencies": {
-    "assemblyscript": "^0.22.0"
+    "assemblyscript": "^0.25.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/ttulka/as-big/issues/9

The build is failing with assembly script >0.25.0 because the compiler fails to detect that `cmp` is always set in the for loop. By initializing the variable to 0, we have the same behaviour and the compiler is happy.

I also removed in unused variable `bt` in the same function and exposed constants for the rounding types.